### PR TITLE
Reduce logging output in production.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 21d8037fec23ff66a470bd9a7457bef13ee37c46814a39df755073ad3ca8520c
-updated: 2017-01-25T12:09:14.839532594Z
+hash: db4aa16d8b96c6c3d6d78cd96e731f44b8a707c0c88256343de3689d96cb6b25
+updated: 2018-10-30T20:13:51.301986Z
 imports:
 - name: github.com/gin-contrib/cors
   version: da1a40b05afa495152b4cd508325ccd2b91df28c
@@ -12,6 +12,8 @@ imports:
   version: 2402d76f3d41f928c7902a765dfc872356dd3aad
   subpackages:
   - proto
+- name: github.com/hashicorp/logutils
+  version: a335183dfd075f638afcc820c90591ca3c97eba6
 - name: github.com/manucorporat/sse
   version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
 - name: github.com/mattn/go-isatty

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,6 +7,7 @@ import:
 - package: github.com/oschwald/geoip2-golang
 - package: github.com/gin-contrib/cors
 - package: gopkg.in/gin-gonic/gin.v1
+- package: github.com/hashicorp/logutils
 testImport:
 - package: github.com/totherme/nosj
 - package: github.com/xeipuuv/gojsonpointer

--- a/main.go
+++ b/main.go
@@ -2,14 +2,23 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 
+	"github.com/hashicorp/logutils"
 	geoip2 "github.com/oschwald/geoip2-golang"
 	"github.com/thoughtbot/location/locator"
 	"github.com/thoughtbot/location/web"
 )
 
 func main() {
+	filter := &logutils.LevelFilter{
+		Levels:   []logutils.LogLevel{"DEBUG", "WARN", "ERROR"},
+		MinLevel: logutils.LogLevel("WARN"),
+		Writer:   os.Stderr,
+	}
+	log.SetOutput(filter)
+
 	db, err := geoip2.Open("data/GeoLite2-City.mmdb")
 	if err != nil {
 		fmt.Println("Unable to read GeoLite DB")

--- a/web/location_handler.go
+++ b/web/location_handler.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 
 	"github.com/thoughtbot/location/locator"
-
 	"gopkg.in/gin-gonic/gin.v1"
 )
 
@@ -33,7 +32,7 @@ func (h *locationHandler) handleNearest(c *gin.Context) {
 	officeURL := o.URL(h.thoughtbotURL)
 
 	log.Printf(
-		"Nearest Offce: Matched %s office (distance %f) for IP %s",
+		"[DEBUG] Nearest Office: Matched %s office (distance %f) for IP %s",
 		o.Name,
 		distanceKm,
 		clientIP,


### PR DESCRIPTION
When the location handler is called, it will log the nearest office
match. This isn't really necessary and removing a line will reduce how
much log data we're storing.

Uses https://github.com/hashicorp/logutils.